### PR TITLE
Enh/fake post todo

### DIFF
--- a/src/redux/todos/thunks.ts
+++ b/src/redux/todos/thunks.ts
@@ -1,8 +1,9 @@
 import { Dispatch } from "redux";
 import { Todo } from "./state";
 import { createTodoSuccess, failed, ITodosAction, loadTodosSuccess, removeTodoSuccess, updateTodoSuccess } from "./actions";
-import { fetchTodos, postTodo } from "../../services/jsonPlaceholderApi";
+import { fetchTodos } from "../../services/jsonPlaceholderApi";
 import checkSuccessfulStatus from "../../utils/checkSuccessfulStatus";
+import createUuid from "../../utils/createUuid";
 
 const limit = 10;
 
@@ -16,12 +17,15 @@ export function loadTodos(userId: number) {
 }
 
 export function createTodo(newTodo: Todo) {
-  return async (dispatch: Dispatch<ITodosAction>) => {
-    const { status, statusText, data } = await postTodo(newTodo);
+  const id = createUuid();
+  return (dispatch: Dispatch<ITodosAction>) => dispatch(createTodoSuccess({ ...newTodo, id }));
+  /* Working code - commented out for performance concern since the Json Placeholder API are faked */
+  // return async (dispatch: Dispatch<ITodosAction>) => {
+  //   const { status, statusText, data } = await postTodo(newTodo);
 
-    if (checkSuccessfulStatus(status)) dispatch(createTodoSuccess(data as Todo));
-    else dispatch(failed('CREATE_TODO_FAILED', statusText));
-  };
+  //   if (checkSuccessfulStatus(status)) dispatch(createTodoSuccess(data as Todo));
+  //   else dispatch(failed('CREATE_TODO_FAILED', statusText));
+  // };
 }
 
 export function updateTodo(updatedTodo: Todo) {

--- a/src/utils/createUuid.ts
+++ b/src/utils/createUuid.ts
@@ -1,0 +1,3 @@
+export default function createUuid() {
+  return performance.now();
+}


### PR DESCRIPTION
### Descriptions
- Comment out `postTodo` and manually assign uuid to `newTodo` to avoid duplicate `key` error when multiple new `todo` items are created

### Stories
- [x] Create `createUuid` util
- [x] Comment out `postTodo` and manually assign uuid to `newTodo` to avoid duplicate `key` error when multiple new `todo` items are created